### PR TITLE
Add addMesh()

### DIFF
--- a/src/gepetto_viewer_rerun/client.py
+++ b/src/gepetto_viewer_rerun/client.py
@@ -110,42 +110,42 @@ class Gui:
                 every '/' will interpreted as a tree
             - if there is no '/', archetype will require addToGroup() to be logged
         """
+
+        def create_entity(entity_name) -> Entity:
+            """Create entity and add it to self.entity_list"""
+            entity = Entity(entity_name, archetype, [self.scene_list[scene_index]])
+            self.entity_list.append(entity)
+            return entity
+
         assert archetype is not None, "_parse_entity(): 'entity' must not be None"
         assert isinstance(
             archetypeType, Archetype
         ), "_parse_entity(): 'archetypeType' must be of type `enum Archetype`"
 
         char_index = archetypeName.find("/")
-        # If archetypeName contains '/' then search for the scene in self.scene_list
+        # If archetypeName contains '/' then search for the node
         if char_index != -1 and char_index != len(archetypeName) - 1:
-            scene_name = archetypeName[:char_index]
-            scene_index = self._get_scene_index(scene_name)
-
+            node_name = archetypeName[:char_index]
+            scene_index = self._get_scene_index(node_name)
             if scene_index != -1:
-                entity_name = archetypeName[char_index + 1 :]
-                entity = Entity(entity_name, archetype, self.scene_list[scene_index])
-                self.entity_list.append(entity)
-
-                if archetypeType == Archetype.MESH_FROM_PATH:
-                    # There is a bug with `log_file_from_path` and recordings.
-                    # That's why we call `rec.to_native()`.
-                    # 19/11/2024 - Issue : https://github.com/rerun-io/rerun/issues/8167
-                    rr.log_file_from_path(
-                        file_path=entity.archetype.path,
-                        recording=self.scene_list[scene_index].rec.to_native(),
-                    )
-                else:
-                    entity.add_log_name(entity_name)
-                    rr.log(
-                        entity_name,
-                        entity.archetype,
-                        recording=self.scene_list[scene_index].rec,
-                    )
-                msg = (
+                entity = create_entity(archetypeName[char_index + 1 :])
+                if archetypeType != Archetype.MESH_FROM_PATH:
+                    entity.add_log_name(entity.name)
+                logger.info(
                     f"_parse_entity(): Creates entity {archetypeName} of type {archetypeType.name}, "
-                    f"and logs it directly to '{self.scene_list[scene_index].name}' scene."
+                    f"and call to _log_entity()."
                 )
-                logger.info(msg)
+                self._log_entity(entity)
+                self._draw_spacial_view_content()
+                return
+            if self._group_exists(node_name):
+                entity = create_entity(archetypeName[char_index + 1 :])
+                logger.info(
+                    f"_parse_entity(): Creates entity {archetypeName} of type {archetypeType.name}, "
+                    f"and call to _add_entity_to_group()."
+                )
+                self._add_entity_to_group(entity, node_name)
+                self._draw_spacial_view_content()
                 return
         # Put entity to entity_list, wait for addToGroup() to be logged
         entity = Entity(archetypeName, archetype)
@@ -483,6 +483,11 @@ class Gui:
         return next(
             (scene.rec for scene in self.scene_list if scene.name == recName), None
         )
+
+    def _group_exists(self, group_name: str) -> bool:
+        for group in self.group_list:
+            if group.name == group_name:
+                return True
 
     def _log_entity(self, entity: Entity):
         """Draw a group entity in the Viewer."""

--- a/src/gepetto_viewer_rerun/client.py
+++ b/src/gepetto_viewer_rerun/client.py
@@ -492,25 +492,25 @@ class Gui:
     def _log_entity(self, entity: Entity):
         """Draw a group entity in the Viewer."""
         if not entity.scenes:
-            logger.info(
+            logger.error(
                 f"_log_entity(): Logging entity '{entity.name}' don't have any scenes to be displayed in."
             )
             return False
         for scene in entity.scenes:
             for log_name in entity.log_name:
-                if type(entity.archetype) is rr.archetypes:
-                    rr.log(
-                        log_name,
-                        entity.archetype,
-                        recording=scene.rec,
-                    )
-                elif isinstance(entity.archetype, MeshFromPath):
+                if isinstance(entity.archetype, MeshFromPath):
                     # entity_path_prefix does not seem to work here
                     # 06/12/2024 - Linked isssue : https://github.com/rerun-io/rerun/issues/8344
                     rr.log_file_from_path(
                         file_path=entity.archetype.path,
                         entity_path_prefix=log_name,
-                        recording=scene.rec.to_native(),
+                        recording=scene.rec,
+                    )
+                else:
+                    rr.log(
+                        log_name,
+                        entity.archetype,
+                        recording=scene.rec,
                     )
             logger.info(
                 f"_log_entity(): Logging entity '{entity.name}' in '{scene.name}' scene."

--- a/src/gepetto_viewer_rerun/client.py
+++ b/src/gepetto_viewer_rerun/client.py
@@ -505,6 +505,8 @@ class Gui:
                         recording=scene.rec,
                     )
                 elif isinstance(entity.archetype, MeshFromPath):
+                    # entity_path_prefix does not seem to work here
+                    # 06/12/2024 - Linked isssue : https://github.com/rerun-io/rerun/issues/8344
                     rr.log_file_from_path(
                         file_path=entity.archetype.path,
                         entity_path_prefix=log_name,
@@ -718,7 +720,9 @@ class Gui:
             content = []
             for entity in self.entity_list:
                 if isinstance(entity.archetype, MeshFromPath):
-                    content.append("+ " + entity.archetype.path)
+                    if scene in entity.scenes:
+                        for log_name in entity.log_name:
+                            content.append("+ " + log_name + entity.archetype.path)
                 else:
                     if scene in entity.scenes:
                         for log_name in entity.log_name:

--- a/src/gepetto_viewer_rerun/client.py
+++ b/src/gepetto_viewer_rerun/client.py
@@ -36,9 +36,7 @@ class Gui:
         """
         scene_list : List of `Scene` class (name and associated recording)
         window_list : List of all window names
-        entity_list : List containing every Rerun archetypes,
-                    each archetypes contain a list of `Entity` class.
-                    Use `Enum Archetype` to get indices.
+        entity_list : List containing every objects created wrapped in Entity.
         """
 
         self.scene_list = []

--- a/src/gepetto_viewer_rerun/entity.py
+++ b/src/gepetto_viewer_rerun/entity.py
@@ -33,6 +33,15 @@ class Entity:
 
 @dataclass
 class MeshFromPath:
+    """
+    Meshes in Gepetto Viewer are not what Rerun Mesh3D are.
+    Meshes in Gepetto Viewer are files containing data.
+    Meshes in Rerun are an archetype that takes data as arguments to be build.
+
+    MeshFromPath is only used when calling addMesh() on collada files.
+    When addMesh() is called on stl/obj files, we will use Asset3D archetype
+    """
+
     path: str | Path
 
 

--- a/src/gepetto_viewer_rerun/entity.py
+++ b/src/gepetto_viewer_rerun/entity.py
@@ -1,7 +1,7 @@
 import rerun as rr
 from dataclasses import dataclass, field
 from typing import List
-import pathlib
+from pathlib import Path
 from .scene import Scene
 
 
@@ -33,7 +33,7 @@ class Entity:
 
 @dataclass
 class MeshFromPath:
-    path: str | pathlib.Path
+    path: str | Path
 
 
 @dataclass


### PR DESCRIPTION
For now, in external data loader, only `filepath` and `entity_path_prefix` are transmitted.

So here, I use `entity_path_prefix` to transmit the actual `entity_path` to the data loader, so that it logs the file as '*entity_path_prefix*'.

See dataloader : https://github.com/Gepetto/rerun-loader-collada/compare/main...EtaLoop:rerun-loader-collada:entity-path

I have opened an issue about the possibility of adding `entity_path` to `log_file_from_path`.
See : https://github.com/rerun-io/rerun/issues/8364